### PR TITLE
fix Celery Result backend. DisabledBackend object has no attribute _g…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache
 .DS_Store
+.idea

--- a/project/main.py
+++ b/project/main.py
@@ -1,10 +1,9 @@
-from celery.result import AsyncResult
 from fastapi import Body, FastAPI, Form, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from worker import create_task
+from worker import create_task, celery
 
 
 app = FastAPI()
@@ -27,7 +26,7 @@ def run_task(payload = Body(...)):
 
 @app.get("/tasks/{task_id}")
 def get_status(task_id):
-    task_result = AsyncResult(task_id)
+    task_result = celery.AsyncResult(task_id)
     result = {
         "task_id": task_id,
         "task_status": task_result.status,


### PR DESCRIPTION
`curl http://localhost:8004/tasks/<TASK_ID>` will raise 

`AttributeError: 'DisabledBackend' object has no attribute '_get_task_meta_for'` 

root cause:   

  `celery` modules doesn't contain `result_backend` conf.

Fix:  

  Use `celery` instance in `worker.py` just to solve this problem