### PR TITLE
chore: bump dependancies

### DIFF
--- a/project/Dockerfile
+++ b/project/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.9.5-slim-buster
+FROM python:3.11.2-slim-buster
 
 # set work directory
 WORKDIR /usr/src/app

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -4,3 +4,4 @@ Jinja2==3.1.2
 pytest==7.2.2
 requests==2.28.2
 uvicorn==0.21.1
+httpx==0.23.3

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,6 +1,6 @@
-aiofiles==0.6.0
-fastapi==0.64.0
-Jinja2==2.11.3
-pytest==6.2.4
-requests==2.25.1
-uvicorn==0.13.4
+aiofiles==23.1.0
+fastapi==0.95.0
+Jinja2==3.1.2
+pytest==7.2.2
+requests==2.28.2
+uvicorn==0.21.1


### PR DESCRIPTION
- Bump requirements and docker images versions
- Add `httpx` to the requirements for pytest usage